### PR TITLE
Fixed log configuration

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -26,5 +26,6 @@ class HelloWorld
   end
 end
 
+Agoo::Server.handle(nil, '**', HelloWorld.new)
 Agoo::Server.start()
 

--- a/server.rb
+++ b/server.rb
@@ -1,29 +1,27 @@
 require 'agoo'
 
-Agoo::Server.init(3000, 'public',
-  thread_count: 0,
-  worker_count: 1,
-  root_first: true,
+Agoo::Log.configure(dir: 'log',
+		    console: true,
+		    classic: true,
+		    colorize: true,
+		    states: {
+		      INFO: true,
+		      DEBUG: false,
+		      connect: true,
+		      request: true,
+		      response: true,
+		      eval: true,
+		      push: true,
+		    })
 
-  log_dir: 'tmp/log',
-  log_classic: true,
-  log_colorize: true,
-  log_console: true,
-  log_states: {
-    INFO: true,
-    DEBUG: true,
-    connect: true,
-    request: true,
-    response: true,
-    eval: true
-  })
+Agoo::Server.init(3000, 'public',
+		  thread_count: 0,
+		  worker_count: 1,
+		  root_first: true,
+		 )
 
 class HelloWorld
   def call(env)
     [200, {}, ["Found"]]
   end
 end
-
-Agoo::Server.handle(nil, '**', HelloWorld.new)
-Agoo::Server.start
-

--- a/server.rb
+++ b/server.rb
@@ -25,3 +25,6 @@ class HelloWorld
     [200, {}, ["Found"]]
   end
 end
+
+Agoo::Server.start()
+


### PR DESCRIPTION
I changed the log configuration but otherwise did not change anything. On a Ubuntu 18.04 machine it worked as expected. Please make sure you are using the `develop` branch. Here is what I got.

```
razer agoo-root-first-test (master)> ruby -I ../agoo/ext -I../lib/agoo/lib server.rb 
I 2018/06/04 17:05:10.591485381 INFO: Agoo 2.2.0 with pid 4105 is listening on port 3000.
I 2018/06/04 17:05:17.226274083 connect: Server with pid 4105 accepted connection 1 on port 3000 [17]
I 2018/06/04 17:05:17.226527183 request: 1: GET /robots.txt HTTP/1.1
Host: localhost:3000
User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-GB,en;q=0.5
Accept-Encoding: gzip, deflate
Connection: keep-alive
Upgrade-Insecure-Requests: 1
I 2018/06/04 17:05:17.226725805 response: 1: HTTP/1.1 200 OK
Content-Type: text/plain
Content-Length: 7
I 2018/06/04 17:05:22.740607893 connect: Connection 1 closed.
I 2018/06/04 17:05:24.076836256 connect: Server with pid 4105 accepted connection 2 on port 3000 [17]
I 2018/06/04 17:05:24.077093302 request: 2: GET / HTTP/1.1
Host: localhost:3000
User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-GB,en;q=0.5
Accept-Encoding: gzip, deflate
Connection: keep-alive
Upgrade-Insecure-Requests: 1
I 2018/06/04 17:05:24.077492807 response: 2: HTTP/1.1 200 OK
Content-Length: 5
^CI 2018/06/04 17:05:28.373961748 INFO: Agoo with pid 4105 shutting down.
```

I will test on a macOS machine as well shortly.